### PR TITLE
Speedup rust version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 # Copyright 2017 Samuel Lampa
 # samuel dot lampa at farmbio dot uu dot se
-TIMECMD=gtime -f %e
+TIMECMD=/usr/bin/time -f %e
 
 Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa.gz:
 	wget ftp://ftp.ensembl.org/pub/release-67/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa.gz
-	gunzip Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa.gz
 
-#%: %.gz
-#	zcat $< > $@
+%: %.gz
+	zcat $< > $@
 
 get_data: Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # Copyright 2017 Samuel Lampa
 # samuel dot lampa at farmbio dot uu dot se
-TIMECMD=/usr/bin/time -f %e
+TIMECMD=gtime -f %e
 
 Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa.gz:
 	wget ftp://ftp.ensembl.org/pub/release-67/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa.gz
+	gunzip Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa.gz
 
-%: %.gz
-	zcat $< > $@
+#%: %.gz
+#	zcat $< > $@
 
 get_data: Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bstr = "0.2.15"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use bstr::io::BufReadExt;
 
 fn main() {
     let filename = "Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa";
@@ -11,21 +12,21 @@ fn main() {
     let mut at = 0;
     let mut gc = 0;
     // Read the file line by line using the lines() iterator from std::io::BufRead.
-    for line in reader.lines() {
-        let line = line.unwrap(); // Ignore errors.
-        if line.starts_with(">") {
-            continue;
+    reader.for_byte_line( |line|  {
+        if line.first() == Some(&b'>') {
+            return Ok(true)
         }
-        for c in line.chars() {
+        for c in line {
             match c {
-                'G' => gc += 1,
-                'C' => gc += 1,
-                'A' => at += 1,
-                'T' => at += 1,
+                b'G' => gc += 1,
+                b'C' => gc += 1,
+                b'A' => at += 1,
+                b'T' => at += 1,
                 _ => (),
             }
         }
-    }
+	Ok(true)
+    });
     let gc_ratio: f64 = gc as f64 / (gc as f64 + at as f64);
     println!("GC ratio (gc/(gc+at)): {}", gc_ratio);
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,32 +1,25 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufReader};
 use bstr::io::BufReadExt;
 
 fn main() {
     let filename = "Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa";
-
+    
+    let mut cc: [u32; 256] = [0; 256];
     // Open the file in read-only mode (ignoring errors).
     let file = File::open(filename).unwrap();
     let reader = BufReader::new(file);
 
-    let mut at = 0;
-    let mut gc = 0;
     // Read the file line by line using the lines() iterator from std::io::BufRead.
     reader.for_byte_line( |line|  {
         if line.first() == Some(&b'>') {
             return Ok(true)
         }
-        for c in line {
-            match c {
-                b'G' => gc += 1,
-                b'C' => gc += 1,
-                b'A' => at += 1,
-                b'T' => at += 1,
-                _ => (),
-            }
-        }
+        for c in line { cc[*c as usize] += 1; }
 	Ok(true)
-    });
+    }).unwrap();
+    let gc = cc[b'G' as usize] + cc[b'C' as usize];
+    let at = cc[b'A' as usize] + cc[b'T' as usize];
     let gc_ratio: f64 = gc as f64 / (gc as f64 + at as f64);
     println!("GC ratio (gc/(gc+at)): {}", gc_ratio);
 }


### PR DESCRIPTION
The rust version, by default, takes a number of hits that other versions don't.  First, rust, by default, does UTF validation on input, which can be costly.  Here, like in the other versions, we assume the input is valid as ASCII.  Second, the `lines()` iterator incurs a `String` allocation for each line — this version should avoid that cost as well.  It *does* use the `bstr` crate to make doing this easy, but something similar should be achievable without the crate as well, but with a little bit more code.