### PR TITLE
Add "two additions for the price of one" C and C++ implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa*
+*.time
+gc
+*.o

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,18 @@ cpp.time: cpp/gc get_data
 	cat .$@.tmp | awk "{ SUM += \$$1 } END { print SUM/3.0 }" > $@
 	rm .$@.tmp
 
+cpp.001/gc: cpp.001/gc.cpp
+	g++ -O3 -Wall -o $@ cpp.001/gc.cpp
+
+cpp.001.time: cpp.001/gc get_data
+	${TIMECMD} cpp.001/gc 2> .$@.tmp
+	sleep 0.1
+	${TIMECMD} cpp.001/gc 2>> .$@.tmp
+	sleep 0.1
+	${TIMECMD} cpp.001/gc 2>> .$@.tmp
+	cat .$@.tmp | awk "{ SUM += \$$1 } END { print SUM/3.0 }" > $@
+	rm .$@.tmp
+
 c/gc:
 	bash -c 'cd c/ && gcc -O3 -ogc gc.c && cd ..;'
 
@@ -31,6 +43,18 @@ c.time: c/gc get_data
 	${TIMECMD} ./c/gc 2>> .$@.tmp
 	sleep 0.1
 	${TIMECMD} ./c/gc 2>> .$@.tmp
+	cat .$@.tmp | awk "{ SUM += \$$1 } END { print SUM/3.0 }" > $@
+	rm .$@.tmp
+
+c.001/gc: c.001/gc.c
+	gcc -O3 -Wall -o $@ c.001/gc.c
+
+c.001.time: c.001/gc get_data
+	${TIMECMD} c.001/gc 2> .$@.tmp
+	sleep 0.1
+	${TIMECMD} c.001/gc 2>> .$@.tmp
+	sleep 0.1
+	${TIMECMD} c.001/gc 2>> .$@.tmp
 	cat .$@.tmp | awk "{ SUM += \$$1 } END { print SUM/3.0 }" > $@
 	rm .$@.tmp
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,18 @@ c.001.time: c.001/gc get_data
 	cat .$@.tmp | awk "{ SUM += \$$1 } END { print SUM/3.0 }" > $@
 	rm .$@.tmp
 
+c.002.rawio/gc: c.002.rawio/gc.c
+	gcc -O3 -Wall -o $@ c.002.rawio/gc.c
+
+c.002.rawio.time: c.002.rawio/gc get_data
+	${TIMECMD} c.002.rawio/gc 2> .$@.tmp
+	sleep 0.1
+	${TIMECMD} c.002.rawio/gc 2>> .$@.tmp
+	sleep 0.1
+	${TIMECMD} c.002.rawio/gc 2>> .$@.tmp
+	cat .$@.tmp | awk "{ SUM += \$$1 } END { print SUM/3.0 }" > $@
+	rm .$@.tmp
+
 d/gc:
 	bash -c 'cd d/ && ldc2 -O5 -boundscheck=off -release gc.d && cd ..;'
 

--- a/c.001/gc.c
+++ b/c.001/gc.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdint.h>
+
+uint64_t value[256] = { 0 };
+
+int main()
+{
+    FILE *f = fopen("Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa", "r");
+    if (f == NULL) { perror("Can't open input file"); return 1; }
+
+    value['A'] = value['T'] = 1;
+    value['G'] = value['C'] = 1ull << 32;
+
+    uint64_t totals = 0;
+
+    char line[4096];
+    while (fgets(line, sizeof line, f)) {
+        if (line[0] == '>') continue;
+
+        unsigned char *s = (unsigned char *) line;
+        unsigned char c;
+        while ((c = *s++) != '\0')
+            totals += value[c];
+    }
+
+    fclose(f);
+
+    double at = totals & 0xFFFFFFFFull;
+    double gc = totals >> 32;
+
+    printf("%.10f\n", gc / (at + gc) * 100.0);
+    return 0;
+}

--- a/c.002.rawio/gc.c
+++ b/c.002.rawio/gc.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+uint64_t value[256] = { 0 };
+
+int main(int argc, char **argv)
+{
+    size_t buflen = (argc > 1)? strtoul(argv[1], NULL, 0) : 32768;
+    unsigned char *buffer = malloc(buflen + 1);
+    if (buffer == NULL) { perror("Can't allocate buffer"); return 1; }
+
+    int fd = open("Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa", O_RDONLY);
+    if (fd < 0) { perror("Can't open input file"); return 1; }
+
+    value['A'] = value['T'] = 1;
+    value['G'] = value['C'] = 1ull << 32;
+
+    uint64_t totals = 0;
+
+    int in_header_line = 0;
+    ssize_t nread;
+    while ((nread = read(fd, buffer, buflen)) > 0) {
+        buffer[nread] = '>';
+
+        // If we're part-way through a header line, get back to that mode
+        if (in_header_line && buffer[0] != '\n') buffer[0] = '>';
+        in_header_line = 0;
+
+        unsigned char *s = buffer;
+        for (;;) {
+            unsigned char c = *s++;
+
+            if (__builtin_expect(c != '>', 1)) totals += value[c];
+            else if (s >= &buffer[nread]) goto read_again;
+            else {
+                // Skip to the end of the header line
+                while ((c = *s++) != '\n')
+                    if (c == '>' && s >= &buffer[nread]) {
+                        in_header_line = 1;
+                        goto read_again;
+                    }
+            }
+        }
+
+        read_again: ;
+    }
+
+    free(buffer);
+    close(fd);
+
+    double at = totals & 0xFFFFFFFFull;
+    double gc = totals >> 32;
+
+    printf("%.10f\n", gc / (at + gc) * 100.0);
+    return 0;
+}

--- a/cpp.001/gc.cpp
+++ b/cpp.001/gc.cpp
@@ -1,0 +1,34 @@
+#include <fstream>
+#include <iostream>
+#include <stdint.h>
+
+uint64_t value[256] = { 0 };
+
+int main()
+{
+    std::ifstream f("Homo_sapiens.GRCh37.67.dna_rm.chromosome.Y.fa");
+    if (! f.is_open()) return 1;
+
+    value['A'] = value['T'] = 1;
+    value['G'] = value['C'] = 1ull << 32;
+
+    uint64_t totals = 0;
+
+    std::string line;
+    while (getline(f, line)) {
+        const unsigned char *s =
+            reinterpret_cast<const unsigned char *>(line.c_str());
+
+        if (*s == '>') continue;
+
+        unsigned char c;
+        while ((c = *s++) != '\0')
+            totals += value[c];
+    }
+
+    double at = totals & 0xFFFFFFFFull;
+    double gc = totals >> 32;
+
+    std::cout << gc / (at + gc) * 100.0 << '\n';
+    return 0;
+}


### PR DESCRIPTION
This is an optimisation of _c/gc.c_'s branch-free large-table-of-increments technique that only requires one table lookup for each character instead of two. Like many of the existing implementations, it only works on files up to 4 GiB or so. It saves about 30% compared to _c/gc_ on my machine, so it will be interesting to see where these rank on yours.

BTW I rather agree with [Nils](https://twitter.com/nilshomer/status/1362480872981626884) that startup costs are probably overrepresented in these short runtimes. It might be instructive to just concatenate the input file onto itself ten (or 35, which takes it to ~2 GiB) times and recalibrate the timing table.