### PR TITLE
Optimize compiler options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,11 +227,11 @@ pypy/gc.bin: pypy/gc.py
 
 # Rust
 rust/gc.bin: rust/src/main.rs rust/Cargo.toml
-	cargo build --release --manifest-path $(word 2,$^) -Z unstable-options --out-dir $(shell dirname $@) \
+	RUSTFLAGS="-C target-cpu=native" cargo build --release --manifest-path $(word 2,$^) -Z unstable-options --out-dir $(shell dirname $@) \
 		&& mv $(basename $@) $@
 
 rust%/gc.bin: rust%/src/main.rs rust%/Cargo.toml
-	cargo build --release --manifest-path $(word 2,$^) -Z unstable-options --out-dir $(shell dirname $@) \
+	RUSTFLAGS="-C target-cpu=native" cargo build --release --manifest-path $(word 2,$^) -Z unstable-options --out-dir $(shell dirname $@) \
 		&& mv $(basename $@) $@
 
 #TODO: Update

--- a/rust.001/Cargo.toml
+++ b/rust.001/Cargo.toml
@@ -6,4 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [dependencies]

--- a/rust.002.bitshift/Cargo.toml
+++ b/rust.002.bitshift/Cargo.toml
@@ -6,4 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [dependencies]

--- a/rust.003.vectorized/Cargo.toml
+++ b/rust.003.vectorized/Cargo.toml
@@ -6,4 +6,8 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,5 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [dependencies]
 bstr = "0.2.15"


### PR DESCRIPTION
Makes the previously mentioned changes to optimize the compiled binaries. 

I'm also hoping that cpu-native leads to the correct simd instructions being added for the vectorized version on the benchmarking  machine. On my computer the vectorized version is about .03s off of the C raw io version. 