### PR TITLE
Add Crystal version that avoids allocating strings

### DIFF
--- a/crystal.002.peek/gc.cr
+++ b/crystal.002.peek/gc.cr
@@ -1,5 +1,4 @@
 gcfile = File.new("chry_multiplied.fa")
-gcfile.buffer_size = ARGV[0].to_i
 
 at = 0
 gc = 0

--- a/crystal.002.peek/gc.cr
+++ b/crystal.002.peek/gc.cr
@@ -1,0 +1,75 @@
+gcfile = File.new("chry_multiplied.fa")
+gcfile.buffer_size = ARGV[0].to_i
+
+at = 0
+gc = 0
+
+while true
+  # Peek the IO's buffer
+  peek = gcfile.peek
+
+  # If there's nothing else, we reached the end
+  break if peek.empty?
+
+  # If the line starts with '>' it's a comment
+  if peek[0] === '>'
+    while true
+      # See where the line ends
+      newline_index = peek.index('\n'.ord)
+
+      # If we find an end, skip until past the newline and continue analyzing
+      if newline_index
+        gcfile.skip(newline_index + 1)
+        break
+      end
+
+      # Otherwise we must continue looking for that newline,
+      # so we skip the entire peek buffer and read more
+      gcfile.skip(peek.size)
+      peek = gcfile.peek
+
+      # Maybe we reached the end?
+      break if peek.empty?
+    end
+
+    # Here we found the newline, so we analyze the next line
+    next
+  end
+
+  # This is not a comment line so we read until the next line
+  while true
+    # See where the line ends
+    newline_index = peek.index('\n'.ord)
+
+    # How many bytes we need to analyze: either until the newline or the entire buffer
+    analyze_size = newline_index || peek.size
+
+    # Analyze the bytes
+    peek[0, analyze_size].each do |byte|
+      case byte
+      when 'A', 'T'
+        at += 1
+      when 'G', 'C'
+        gc += 1
+      end
+    end
+
+    # If we found a newline, we are done
+    if newline_index
+      gcfile.skip(newline_index + 1)
+      break
+    end
+
+    # Otherwise we are still in a non-comment line
+    gcfile.skip(peek.size)
+    peek = gcfile.peek
+
+    # Maybe we reached the end?
+    break if peek.empty?
+  end
+end
+
+gcfile.close
+
+gcfrac = gc / (gc + at)
+puts "GC fraction: #{gcfrac}"


### PR DESCRIPTION
Per [request](https://twitter.com/smllmp/status/1363752773435678721), this adds a Crystal version that avoids allocating any strings. Every `IO` has a `#peek` method that returns, if the IO is buffered, a slice to the internal buffer. This buffer can then be used to traverse the data to avoid memory allocation. It's a bit low level, but it's safe to use.

Ideally there should be a nicer API for doing this (traversing lines or chunks as byte slices), but it's not currently there.