### PR TITLE
nim memfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ report.md: c.time c.version \
 	java.time java.version \
 	graalvm.time graalvm.version \
 	nim.time nim.version \
+	nim.001.time nim.version \
 	node.time node.version \
 	perl.time perl.version \
 	pypy.time pypy.version \
@@ -209,7 +210,7 @@ julia/gc.bin: julia/gc.jl
 
 # Nim
 %.bin: %.nim
-	nim c -d:danger --opt:speed --checks:off $< \
+	nim c -d:danger $< \
 		&& mv $(basename $@) $@
 
 # Node

--- a/nim.001/gc.nim
+++ b/nim.001/gc.nim
@@ -1,0 +1,32 @@
+import strutils
+import memfiles
+
+proc process(filename: string) =
+  var
+    input: MemFile
+    gc = 0
+    at = 0
+
+  input = memfiles.open(filename)
+  defer: input.close()
+  for line in memfiles.lines(input):
+    if line[0] != '>':
+      for letter in line:
+        case letter
+        of 'A':
+            at += 1
+        of 'T':
+            at += 1
+        of 'C':
+          gc += 1
+        of 'G':
+          gc += 1
+        else:
+          discard()
+
+  let gcFraction = gc / (gc + at)
+  echo formatFloat(gcFraction * 100, ffDecimal, 4)
+
+
+when isMainModule:
+  process("chry_multiplied.fa")


### PR DESCRIPTION
Implementation using memfiles for nim ~25% faster for me. For compilation only `-d:danger` is needed. I did notice both nim versions ran faster on Nim v1.2.6 compared to Nim v1.4.2.