### PR TITLE
(Slightly) Improve Python and Cython benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,9 @@ report.md: ada.time ada.version \
 	node.time node.version \
 	perl.time perl.version \
 	pypy.time pypy.version \
+	pypy.001.binary.time pypy.version \
 	python.time python.version \
+	python.001.binary.time python.version \
 	rust.time rust.version \
 	rust.001.time rust.version \
 	rust.002.bitshift.time rust.version \
@@ -240,10 +242,16 @@ perl/gc.bin: perl/gc.pl
 python/gc.bin: python/gc.py
 	cp $< $@
 
+python%/gc.bin: python%/gc.py
+	cp $< $@
+
 # Pypy
 # We need to copy the pypy script to the canonical path to simplify the e.g.
 # the cleaning rule
 pypy/gc.bin: pypy/gc.py
+	cp $< $@
+
+pypy%/gc.bin: pypy%/gc.py
 	cp $< $@
 
 # Rust

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean:
 		*/gc.bin \
 		*/gc \
 		*/gc.o \
-		cython/gc.c \
+		cython*/gc.c \
 		java/gc.class \
 		nim/nimcache \
 		rust*/target \
@@ -72,6 +72,7 @@ report.md: ada.time ada.version \
 	crystal.001.csp.time crystal.version \
 	crystal.002.peek.time crystal.version \
 	cython.time cython.version \
+	cython.001.fopen.time cython.version \
 	d.time d.version \
 	fpc.time fpc.version \
 	go.time go.version \
@@ -187,6 +188,10 @@ crystal.001.csp/gc: crystal.001.gc/gc.cr
 cython/gc.bin: cython/gc.pyx
 	cython --embed $< \
 		&& gcc -I/usr/include/python2.7 -O3 -o $@ cython/gc.c -lpython2.7
+
+cython%/gc.bin: cython%/gc.pyx
+	cython --embed $< \
+		&& gcc -I/usr/include/python2.7 -O3 -o $@ $(patsubst %.pyx,%.c,$<) -lpython2.7
 
 # D
 %.bin: %.d

--- a/cython.001.fopen/gc.pyx
+++ b/cython.001.fopen/gc.pyx
@@ -1,3 +1,5 @@
+# cython: boundscheck=False, wraparound=False, initializedcheck=False, cdivision=True
+
 from libc.stdio cimport fopen, fgets, fclose, FILE
 from libc.stdint cimport uint64_t
 
@@ -11,10 +13,6 @@ value[ord('G')] = value[ord('C')] = 1ull << 32;
 
 
 cpdef void main():
-
-
-
-
     cdef FILE*    f
     cdef double   at
     cdef double   gc

--- a/cython.001.fopen/gc.pyx
+++ b/cython.001.fopen/gc.pyx
@@ -1,0 +1,47 @@
+from libc.stdio cimport fopen, fgets, fclose, FILE
+from libc.stdint cimport uint64_t
+
+
+cdef uint64_t value[256];
+
+for i in range(256):
+    value[i] = 0;
+value[ord('A')] = value[ord('T')] = 1;
+value[ord('G')] = value[ord('C')] = 1ull << 32;
+
+
+cpdef void main():
+
+
+
+
+    cdef FILE*    f
+    cdef double   at
+    cdef double   gc
+    cdef char     line[4096]
+    cdef uint64_t totals     = 0
+    cdef size_t   i          = 0
+
+    f = fopen("chry_multiplied.fa","r")
+    if f == NULL:
+        raise OSError("Can't open input file")
+
+    with nogil:
+
+        while fgets(line, sizeof(line), f):
+            if line[0] == '>':
+                continue
+            while line[i] != 0:
+                totals += value[line[i]]
+                i += 1
+            i = 0
+
+        fclose(f)
+        at = totals & 0xFFFFFFFFull;
+        gc = totals >> 32;
+
+    print( gc / (at + gc) )
+
+
+if __name__ == '__main__':
+    main()

--- a/pypy.001.binary/gc.py
+++ b/pypy.001.binary/gc.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env pypy
+import string
+ 
+def main():
+    file = open("chry_multiplied.fa","rb")
+    a = 0
+    t = 0
+    g = 0
+    c = 0
+    for line in file:
+        if line[0] != b">" and len(line) != line.count(b"N") + 1:
+            g += line.count(b"G")
+            c += line.count(b"C")
+            a += line.count(b"A")
+            t += line.count(b"T")
+    totalBaseCount = a + t + c + g
+    gcCount = g + c
+    gcFraction = float(gcCount) / totalBaseCount
+    print( gcFraction * 100 )
+ 
+if __name__ == '__main__':
+    main()

--- a/python.001.binary/gc.py
+++ b/python.001.binary/gc.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import string
+ 
+A,T,G,C,N = map(ord, "ATGCN")
+
+def main():
+    file = open("chry_multiplied.fa","rb")
+    a = 0
+    t = 0
+    g = 0
+    c = 0
+    for line in file:
+        if line[0] != 62 and len(line) != line.count(N) + 1:
+            g += line.count(G)
+            c += line.count(C)
+            a += line.count(A)
+            t += line.count(T)
+    totalBaseCount = a + t + c + g
+    gcCount = g + c
+
+    gcFraction = float(gcCount) / totalBaseCount
+    print( gcFraction * 100 )
+ 
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi there !

It's a very nice project you have, I'm usually too lazy to setup a proper environment for benchmarking but with yours ready I could just pop in some extra benches without trouble.

As a Pythonista, I am aware of Python's abysmal performances regarding I/O, but I was still a bit sad to see it so low in the list. I also looked at the Cython solution and saw that it was clearly not using the whole power of Cython, so here's what I added:

- `python.001.binary` and `pypy.001.binary`: exactly the same logic as the `python` and `pypy` benches, except that the files are opened in binary mode, which should save a bit of time decoding. It doesn't seem to make any difference with PyPy, but it does improve CPython a bit.
- `cython.001.fopen`: a Cython version that actually uses the code from `c.001` in Cython syntax, it runs as fast as `c.001`.

I didn't bench against everything else because I was missing some of the other languages compilers, but here is what I get on my machine (idle Intel NUC with i7-10710U CPU @ 1.10GHz, no particular BIOS setting):

| Language | Time (s) | Compiler or interpreter version |
|----------|----------|---------------------------------|
| [rust.004.simd](rust.004.simd) | 0.271 | rustc 1.46.0-nightly (346aec9b0 2020-07-11) |
| [rust.003.vectorized](rust.003.vectorized) | 0.28 | rustc 1.46.0-nightly (346aec9b0 2020-07-11) |
| [rust.002.bitshift](rust.002.bitshift) | 0.396 | rustc 1.46.0-nightly (346aec9b0 2020-07-11) |
| [rust.001](rust.001) | 0.471 | rustc 1.46.0-nightly (346aec9b0 2020-07-11) |
| [c.001](c.001) | 0.596 | gcc (GCC) 10.2.0 |
| [cython.001.fopen](cython.001.fopen) | 0.603 | Cython version 0.29.21 |
| [cpp.001](cpp.001) | 0.623 | g++ (GCC) 10.2.0 |
| [d](d) | 0.653 | LDC - the LLVM D compiler (1.25.1): based on DMD v2.095.1 |
| [c](c) | 0.718 | gcc (GCC) 10.2.0 |
| [go.001.unroll](go.001.unroll) | 0.796 | go version go1.16.3 linux/amd64 |
| [rust](rust) | 0.871 | rustc 1.46.0-nightly (346aec9b0 2020-07-11) |
| [go](go) | 0.972 | go version go1.16.3 linux/amd64 |
| [c.003.ril](c.003.ril) | 0.981 | gcc (GCC) 10.2.0 |
| [crystal.002.peek](crystal.002.peek) | 0.998 | Crystal 1.0.0 (2021-03-29)  LLVM: 10.0.1 Default |
| [cpp](cpp) | 1.265 | g++ (GCC) 10.2.0 |
| [pypy.001.binary](pypy.001.binary) | 1.342 | Python 2.7.18 (63df5ef41012b07fa6f9eaba93f05de0eb540f88, Apr 11 2021, 17:01:13) [PyPy 7.3.4 with GCC 10.2.0]  |
| [pypy](pypy) | 1.342 | Python 2.7.18 (63df5ef41012b07fa6f9eaba93f05de0eb540f88, Apr 11 2021, 17:01:13) [PyPy 7.3.4 with GCC 10.2.0]  |
| [ada](ada) | 1.942 | GNAT 10.2.0 |
| [crystal.001.csp](crystal.001.csp) | 2.527 | Crystal 1.0.0 (2021-03-29)  LLVM: 10.0.1 Default |
| [crystal](crystal) | 2.581 | Crystal 1.0.0 (2021-03-29)  LLVM: 10.0.1 Default |
| [perl](perl) | 2.768 | This is perl 5, version 32, subversion 1 (v5.32.1) built for x86_64-linux-thread-multi |
| [fpc](fpc) | 3.156 | Free Pascal Compiler version 3.2.0 [2021/03/04] for x86_64 |
| [cython](cython) | 3.3 | Cython version 0.29.21 |
| [python.001.binary](python.001.binary) | 4.073 | Python 3.9.3 |
| [python](python) | 4.421 | Python 3.9.3 |

I'll see if i can find other solutions with Python that make it look a little better, but I don't have any high hopes :sweat_smile: 

Cheers!
